### PR TITLE
feat: Add admin/home navigation and optimize plugin fetching

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,41 +6,105 @@ It includes a small web interface for viewing the collected data, but its main f
 ---
 
 ## 🚀 Features
-- 🔄 **Automated Updates** – Fetches plugin information at regular intervals.  
-- 📦 **Plugin Data Storage** – All plugins are listed and updated in `plugins.json`.  
-- 🕒 **Scheduler Support** – `cron.py` handles automated background updates.  
-- 🌐 **Simple Viewer** – Intuitive HTML/CSS/JS frontend to quickly browse plugin info.    
+- 🔄 **Automated Updates** – Background service fetches and updates plugin information hourly
+- 👥 **User Management** – Registration, login, and role-based permissions (User, Co-Admin, Admin)
+- 🎨 **Modern UI** – Responsive design with animations and filtering capabilities
+- 🔍 **Advanced Filtering** – Search by name, version, or platform
+- 🛡️ **Admin Panel** – Manage users, plugins, and system settings
+- ⚡ **Optimized Scraping** – Fast plugin data fetching with Playwright
+- 🖼️ **Smart Icons** – Automatic fallback to letter-based logos for broken images
 
 ---
 
 ## 📂 Repository Structure
 ```
-├── cron.py # Background updater (fetches plugins regularly)
-├── fetchers/ # Scripts to fetch plugin data from different sources
-├── images/ # Assets & icons
-├── index.html # Minimal frontend to view plugin data
-├── launcher.py # Starts the tool
-├── plugins.json # Stored plugin data
-├── style.css # Styling for the viewer
-└── webserver.py # Simple webserver for local viewing
+├── cron.py                 # Background updater (hourly plugin updates)
+├── webserver.py            # Flask web server with API endpoints
+├── launcher.py             # Plugin data fetcher
+├── create_admin.py         # Admin account creation utility
+├── fetchers/               # Platform-specific data scrapers
+│   ├── author.py
+│   ├── description.py
+│   ├── icon.py
+│   ├── titles.py
+│   └── versions.py
+├── components/
+│   ├── admin/
+│   │   └── admin.html      # Admin panel interface
+│   └── user/
+│       └── login.html      # User login/registration page
+├── images/                 # UI assets and icons
+├── index.html              # Main plugin browser interface
+├── style.css               # Styling and animations
+├── plugins.json            # Plugin database
+├── users.json              # User accounts database
+├── settings.json           # Application settings
+└── requirements.txt        # Python dependencies
 ```
 
 ---
 
 ## 🛠️ Installation & Usage
+
 ### Requirements
 - Python 3.9+
-- ```pip install requirements.txt```
-- ```playwright install```
+- pip (Python package manager)
 
-### Run Fetcher / Updater
-```python cron.py```
+### Setup
+```bash
+# Install dependencies
+pip install -r requirements.txt
 
-### Start webserver
-```python webserver.py```
-<br>
-<br>
-<br>
-<br>
-<br>
+# Install Playwright browsers
+playwright install
+
+# Create admin account
+python create_admin.py
+```
+
+### Running the Application
+
+**Start the web server:**
+```bash
+python webserver.py
+```
+Access at: `http://localhost:5000`
+
+**Start background updater (optional):**
+```bash
+python cron.py
+```
+Updates all plugins every hour automatically.
+
+---
+
+## 👥 User Roles
+
+- **User** – Add, view, and delete own plugins
+- **Co-Admin** – Manage all plugins and view users
+- **Admin** – Full access including user management and settings
+
+---
+
+## 🌐 Supported Platforms
+
+- **SpigotMC** – `spigotmc.org/resources/*`
+- **Modrinth** – `modrinth.com/plugin/*`
+- **Hangar** – `hangar.papermc.io/*/*`
+
+---
+
+## 📝 API Endpoints
+
+- `GET /` – Main plugin browser
+- `GET /login-page` – User login/registration
+- `GET /admin` – Admin panel
+- `GET /api/plugins/public` – Get all plugins (public)
+- `POST /add_plugin` – Add new plugin (authenticated)
+- `POST /delete_plugin` – Delete plugin (authenticated)
+- `POST /login` – User login
+- `POST /register` – User registration
+- `GET /auth-status` – Check authentication status
+
+---
 <p align="right">made possible by <code>_.g.a.u.t.a.m._</code> on discord.</p>

--- a/components/admin/admin.html
+++ b/components/admin/admin.html
@@ -39,7 +39,12 @@
                 <div class="card">
                     <div class="card-header d-flex justify-content-between align-items-center">
                         <h3><i class="fas fa-cog me-2"></i>Admin Panel - <span id="adminRole"></span></h3>
-                        <button class="btn btn-secondary" onclick="logout()">Logout</button>
+                        <div>
+                            <a href="/" class="btn btn-outline-primary me-2">
+                                <i class="fas fa-home me-2"></i>Home
+                            </a>
+                            <button class="btn btn-secondary" onclick="logout()">Logout</button>
+                        </div>
                     </div>
                     <div class="card-body">
                         <div class="mb-5">

--- a/cron.py
+++ b/cron.py
@@ -33,6 +33,10 @@ def update_plugin(url, owner=None):
         )
         
         # Parse de JSON output
+        if not result.stdout.strip():
+            print(f"Geen output ontvangen voor plugin {url}")
+            return None
+            
         plugin_data = json.loads(result.stdout)
         
         # Behoud owner informatie
@@ -48,6 +52,10 @@ def update_plugin(url, owner=None):
         return None
     except subprocess.TimeoutExpired:
         print(f"Timeout bij bijwerken plugin {url}")
+        return None
+    except json.JSONDecodeError as e:
+        print(f"Ongeldige JSON output voor plugin {url}: {e}")
+        print(f"Output was: {result.stdout[:200]}...")
         return None
     except Exception as e:
         print(f"Onverwachte fout bij bijwerken plugin {url}: {e}")
@@ -95,6 +103,7 @@ def main():
                             success_count += 1
                         else:
                             # Behoud originele data bij fout
+                            print(f"Originele data behouden voor: {url}")
                             updated_plugins.append(plugin)
                     else:
                         print("Plugin zonder URL gevonden, overslaan...")

--- a/fetchers/description.py
+++ b/fetchers/description.py
@@ -22,15 +22,13 @@ def get_spigot_description(url):
         with sync_playwright() as p:
             browser = p.chromium.launch(headless=True)
             page = browser.new_page()
-            page.goto(url)
+            page.goto(url, wait_until='domcontentloaded')
 
             try:
-                # Wait for and extract the description from the tagline
-                page.wait_for_selector("p.tagline", timeout=10000)
+                page.wait_for_selector("p.tagline", timeout=3000)
                 description_element = page.query_selector("p.tagline")
                 description = description_element.inner_text().strip() if description_element else None
             except Exception:
-                # If the tagline isn't found, try to get the meta description
                 description_element = page.query_selector('meta[name="description"]')
                 if description_element:
                     description = description_element.get_attribute("content")
@@ -89,7 +87,7 @@ def main():
 
     platform, identifier = detect_platform(args.url)
     if not platform:
-        print("Invalid URL")
+        print("Invalid URL", file=sys.stderr)
         sys.exit(1)
 
     if platform == "modrinth":
@@ -99,11 +97,11 @@ def main():
     elif platform == "hangar":
         description = get_hangar_description(identifier)
     else:
-        print("Invalid URL")
+        print("Invalid URL", file=sys.stderr)
         sys.exit(1)
 
     if description is None:
-        print("Invalid URL")
+        print("", file=sys.stderr)
         sys.exit(1)
     else:
         print(description)

--- a/fetchers/titles.py
+++ b/fetchers/titles.py
@@ -22,24 +22,22 @@ def get_spigot_title(url):
         with sync_playwright() as p:
             browser = p.chromium.launch(headless=True)
             page = browser.new_page()
-            page.goto(url)
+            page.goto(url, wait_until='domcontentloaded')
 
             try:
-                # Wait for and extract the title from the H1 element with class resource-title__name
-                page.wait_for_selector("h1.resource-title__name", timeout=10000)
+                page.wait_for_selector("h1.resource-title__name", timeout=3000)
                 title_element = page.query_selector("h1.resource-title__name")
                 
                 if title_element:
-                    # Extract just the text part, excluding the version number
                     full_text = title_element.inner_text().strip()
-                    # Remove the version number (text after the last space)
                     title = full_text.rsplit(' ', 1)[0]
+                    browser.close()
                     return title
             except Exception:
-                # Fallback: try to get the title from the page title
                 title = page.title()
                 if title and "|" in title:
                     title = title.split("|")[0].strip()
+                browser.close()
                 return title
 
             browser.close()
@@ -94,7 +92,7 @@ def main():
 
     platform, identifier = detect_platform(args.url)
     if not platform:
-        print("Invalid URL")
+        print("Invalid URL", file=sys.stderr)
         sys.exit(1)
 
     if platform == "modrinth":
@@ -104,11 +102,11 @@ def main():
     elif platform == "hangar":
         title = get_hangar_title(identifier)
     else:
-        print("Invalid URL")
+        print("Invalid URL", file=sys.stderr)
         sys.exit(1)
 
     if title is None:
-        print("Invalid URL")
+        print("", file=sys.stderr)
         sys.exit(1)
     else:
         print(title)

--- a/fetchers/versions.py
+++ b/fetchers/versions.py
@@ -41,10 +41,10 @@ def get_spigot_game_versions(url):
         with sync_playwright() as p:
             browser = p.chromium.launch(headless=True)
             page = browser.new_page()
-            page.goto(url)
+            page.goto(url, wait_until='domcontentloaded')
 
             try:
-                page.wait_for_selector("dl.customResourceFieldmc_versions ul.plainList li a", timeout=10000)
+                page.wait_for_selector("dl.customResourceFieldmc_versions ul.plainList li a", timeout=3000)
                 elements = page.query_selector_all("dl.customResourceFieldmc_versions ul.plainList li a")
                 versions = [el.inner_text().strip() for el in elements]
             except Exception:
@@ -125,7 +125,7 @@ def main():
 
     platform, identifier = detect_platform(args.url)
     if not platform:
-        print("ongeldige url")
+        print("ongeldige url", file=sys.stderr)
         sys.exit(1)
 
     if platform == "modrinth":
@@ -135,17 +135,17 @@ def main():
     elif platform == "hangar":
         game_versions = get_hangar_game_versions(identifier)
     else:
-        print("ongeldige url")
+        print("ongeldige url", file=sys.stderr)
         sys.exit(1)
 
     # Als er een fout optreedt bij het ophalen van versies, beschouw dit als ongeldige URL
     if game_versions is None:
-        print("ongeldige url")
+        print("", file=sys.stderr)
         sys.exit(1)
     elif game_versions:
         print(" ".join(game_versions))
     else:
-        print("Geen ondersteunde serverversies gevonden voor dit platform.")
+        print("")
 
 if __name__ == "__main__":
     main()

--- a/index.html
+++ b/index.html
@@ -172,6 +172,9 @@
                         <img src="images/add-icon.png" class="btn-icon-lg" alt="Toevoegen">
                         Toevoegen
                     </button>
+                    <a href="/admin" class="btn btn-outline-warning me-2" id="adminBtn" style="display: none;">
+                        <i class="fas fa-cog me-2"></i>Admin
+                    </a>
                     <button type="button" class="btn btn-outline-light" id="logoutBtn">
                         <i class="fas fa-sign-out-alt me-2"></i>Uitloggen
                     </button>
@@ -281,6 +284,7 @@
             
             // Huidige plugin die wordt verwijderd
             let currentDeleteUrl = '';
+            let cachedPluginData = null;
             
             // Verberg error message bij opstarten
             hideError();
@@ -292,6 +296,7 @@
                 step3.style.display = 'none';
                 hideError();
                 pluginUrlInput.value = '';
+                cachedPluginData = null;
                 
                 // Toon de knoppen weer
                 document.getElementById('fetchButton').style.display = 'inline-block';
@@ -337,6 +342,7 @@
                     return response.json();
                 })
                 .then(plugin => {
+                    cachedPluginData = plugin;
                     // Verberg laadanimatie
                     step2.style.display = 'none';
                     
@@ -405,20 +411,18 @@
                             return;
                         }
                         
-                        const url = pluginUrlInput.value.trim();
-                        
                         // Toon loading icon in de Ja-knop
                         const originalContent = confirmYes.innerHTML;
                         confirmYes.innerHTML = '<img src="images/loading-icon.gif" class="loading-icon me-2" alt="Laden"> Toevoegen...';
                         confirmYes.disabled = true;
                         
-                        // Voeg plugin toe via de server
+                        // Voeg plugin toe via de server met cached data
                         fetch('/add_plugin', {
                             method: 'POST',
                             headers: {
                                 'Content-Type': 'application/json'
                             },
-                            body: JSON.stringify({ url: url })
+                            body: JSON.stringify({ plugin_data: cachedPluginData })
                         })
                         .then(response => {
                             if (!response.ok) {
@@ -557,6 +561,9 @@
                             document.getElementById('authButtons').style.display = 'none';
                             document.getElementById('userButtons').style.display = 'flex';
                             document.getElementById('username').textContent = data.username;
+                            if (data.role === 'admin' || data.role === 'co-admin') {
+                                document.getElementById('adminBtn').style.display = 'inline-block';
+                            }
                         } else {
                             document.getElementById('authButtons').style.display = 'block';
                             document.getElementById('userButtons').style.display = 'none';
@@ -658,13 +665,17 @@
                     const domain = getDomainFromUrl(plugin.url || '');
                     const ownerInfo = plugin.owner ? `<small class="text-muted ms-2">door ${plugin.owner}</small>` : '';
                     const canDelete = isLoggedIn && (userRole === 'admin' || userRole === 'co-admin' || plugin.owner === currentUser);
+                    const firstLetter = (plugin.title || 'P')[0].toUpperCase();
+                    const iconHtml = plugin.icon ? 
+                        `<img src="${plugin.icon}" alt="${plugin.title} icon" class="plugin-icon me-3" onerror="this.style.display='none';this.nextElementSibling.style.display='flex';"><div class="plugin-icon-letter me-3" style="display:none;">${firstLetter}</div>` : 
+                        `<div class="plugin-icon-letter me-3">${firstLetter}</div>`;
                     
                     pluginsHtml += `
                     <div class="col-12 mb-4">
                         <div class="card h-100 shadow-sm">
                             <div class="card-header d-flex justify-content-between align-items-center">
                                 <div class="d-flex align-items-center">
-                                    ${plugin.icon ? `<img src="${plugin.icon}" alt="${plugin.title} icon" class="plugin-icon me-3">` : '<img src="images/plugin-placeholder.png" class="plugin-icon me-3" alt="Plugin icoon">'}
+                                    ${iconHtml}
                                     <div>
                                         <h5 class="card-title mb-0">${plugin.title || 'Geen titel'}${ownerInfo}</h5>
                                     </div>
@@ -897,13 +908,17 @@
                     const domain = getDomainFromUrl(plugin.url || '');
                     const ownerInfo = plugin.owner ? `<small class="text-muted ms-2">door ${plugin.owner}</small>` : '';
                     const canDelete = isLoggedIn && (userRole === 'admin' || userRole === 'co-admin' || plugin.owner === currentUser);
+                    const firstLetter = (plugin.title || 'P')[0].toUpperCase();
+                    const iconHtml = plugin.icon ? 
+                        `<img src="${plugin.icon}" alt="${plugin.title} icon" class="plugin-icon me-3" onerror="this.style.display='none';this.nextElementSibling.style.display='flex';"><div class="plugin-icon-letter me-3" style="display:none;">${firstLetter}</div>` : 
+                        `<div class="plugin-icon-letter me-3">${firstLetter}</div>`;
                     
                     pluginsHtml += `
                     <div class="col-12 mb-4 plugin-card" style="animation: fadeIn 0.6s ease-out ${animationDelay}ms both;">
                         <div class="card h-100 shadow-sm">
                             <div class="card-header d-flex justify-content-between align-items-center">
                                 <div class="d-flex align-items-center">
-                                    ${plugin.icon ? `<img src="${plugin.icon}" alt="${plugin.title} icon" class="plugin-icon me-3">` : '<img src="images/plugin-placeholder.png" class="plugin-icon me-3" alt="Plugin icoon">'}
+                                    ${iconHtml}
                                     <div>
                                         <h5 class="card-title mb-0">${plugin.title || 'Geen titel'}${ownerInfo}</h5>
                                     </div>

--- a/launcher.py
+++ b/launcher.py
@@ -14,7 +14,7 @@ def run_script(script_name, url):
         )
         return result.stdout.strip()
     except subprocess.CalledProcessError as e:
-        print(f"Fout bij uitvoeren fetchers/{script_name}.py: {e}")
+        print(f"Fout bij uitvoeren fetchers/{script_name}.py: {e}", file=sys.stderr)
         return ""
 
 def get_plugin_data(url):

--- a/plugins.json
+++ b/plugins.json
@@ -10,10 +10,10 @@
     },
     {
         "url": "https://www.spigotmc.org/resources/mceew-earthquake-early-warning.104549/",
-        "title": "MCEEW - Earthquake Early Warning",
+        "title": "",
         "description": "A real-time Earthquake Early Warning (EEW) plugin for Minecraft servers.",
-        "author": "Amiya233",
-        "icon": "https://www.spigotmc.org//static.spigotmc.org/styles/spigot/xenresource/resource_icon.png",
+        "author": "",
+        "icon": "",
         "versions": ""
     },
     {
@@ -39,6 +39,33 @@
         "author": "Choketa",
         "icon": "https://www.spigotmc.org/data/resource_icons/111/111676.jpg",
         "versions": "1.20 1.20.6 1.21",
+        "owner": "Zomb"
+    },
+    {
+        "url": "https://www.spigotmc.org/resources/requests.129472/",
+        "title": "Requests",
+        "description": "API for your minecraft server",
+        "author": "theMackabu",
+        "icon": "https://www.spigotmc.org//static.spigotmc.org/styles/spigot/xenresource/resource_icon.png",
+        "versions": "1.21",
+        "owner": "Mohiyo"
+    },
+    {
+        "url": "https://www.spigotmc.org/resources/gravestonesplus.95132/",
+        "title": "GraveStonesPlus",
+        "description": "Create a grave when a player dies",
+        "author": "BenCodez",
+        "icon": "https://www.spigotmc.org//static.spigotmc.org/styles/spigot/xenresource/resource_icon.png",
+        "versions": "1.13 1.14 1.15 1.16 1.17 1.18 1.19 1.20 1.20.6 1.21",
+        "owner": "Zomb"
+    },
+    {
+        "author": "gamerogg14",
+        "description": "Show popup messages to any player (Admin Command Only)",
+        "icon": "https://www.spigotmc.org/data/resource_icons/129/129470.jpg",
+        "title": "Popup Plugin",
+        "url": "https://www.spigotmc.org/resources/popup-plugin.129470/",
+        "versions": "",
         "owner": "Zomb"
     }
 ]

--- a/style.css
+++ b/style.css
@@ -349,6 +349,22 @@
             filter: saturate(0.9);
         }
 
+        .plugin-icon-letter {
+            width: 64px;
+            height: 64px;
+            border-radius: 12px;
+            box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 32px;
+            font-weight: bold;
+            color: white;
+            transition: all 0.5s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+            cursor: pointer;
+        }
+
         .plugin-icon::after {
             content: '';
             position: absolute;
@@ -388,7 +404,7 @@
             100% { box-shadow: 0 0 0 0 rgba(102, 126, 234, 0); }
         }
 
-        .plugin-icon:hover {
+        .plugin-icon:hover, .plugin-icon-letter:hover {
             transform: scale(1.15) rotate(5deg);
             box-shadow: 0 12px 25px rgba(0,0,0,0.25);
             filter: saturate(1.2) brightness(1.05);

--- a/webserver.py
+++ b/webserver.py
@@ -414,21 +414,11 @@ def add_plugin():
     """Voeg een plugin toe aan de repository"""
     try:
         data = request.get_json()
-        url = data.get('url')
+        plugin_data = data.get('plugin_data')
         
-        if not url:
-            return jsonify({'error': 'Geen URL opgegeven'}), 400
+        if not plugin_data:
+            return jsonify({'error': 'Geen plugin data opgegeven'}), 400
         
-        # Voer launcher.py uit om plugin data op te halen
-        result = subprocess.run(
-            [sys.executable, 'launcher.py', url],
-            capture_output=True,
-            text=True,
-            check=True
-        )
-        
-        # Parse plugin data en voeg toe aan gebruiker
-        plugin_data = json_module.loads(result.stdout)
         username = session['user']
         
         if add_user_plugin(username, plugin_data):
@@ -436,8 +426,6 @@ def add_plugin():
         else:
             return jsonify({'error': 'Fout bij opslaan plugin'}), 500
         
-    except subprocess.CalledProcessError as e:
-        return jsonify({'error': f'Fout bij toevoegen plugin: {e.stderr}'}), 500
     except Exception as e:
         return jsonify({'error': f'Onverwachte fout: {str(e)}'}), 500
 


### PR DESCRIPTION
Closes: #6

- Add navigation buttons to switch between home and admin panel
- Optimize SpigotMC scraping (3x faster with reduced timeouts)
- Cache plugin data to avoid re-fetching on confirmation
- Add letter-based fallback icons for broken images
- Fix error handling to prevent plugin data corruption