### PR TITLE
fix: correct version fetching for Spigot and CurseForge platforms

### DIFF
--- a/fetchers/author.py
+++ b/fetchers/author.py
@@ -74,8 +74,14 @@ def get_curseforge_author(url):
         if len(path_parts) < 3:
             return None
         
+        category = path_parts[1]
         project_slug = path_parts[2]
-        api_url = f"https://api.curseforge.com/v1/mods/search?gameId=432&slug={project_slug}"
+        
+        class_id = 6 if category == 'mc-mods' else 4471 if category == 'modpacks' else None
+        if not class_id:
+            return None
+        
+        api_url = f"https://api.curseforge.com/v1/mods/search?gameId=432&slug={project_slug}&classId={class_id}"
         
         headers = {
             'Accept': 'application/json',
@@ -87,7 +93,7 @@ def get_curseforge_author(url):
             return None
         
         data = response.json()
-        if data.get('data') and len(data['data']) > 0:
+        if data.get('data'):
             authors = data['data'][0].get('authors', [])
             if authors:
                 return authors[0].get('name')

--- a/fetchers/description.py
+++ b/fetchers/description.py
@@ -54,8 +54,14 @@ def get_curseforge_description(url):
         if len(path_parts) < 3:
             return None
         
+        category = path_parts[1]
         project_slug = path_parts[2]
-        api_url = f"https://api.curseforge.com/v1/mods/search?gameId=432&slug={project_slug}"
+        
+        class_id = 6 if category == 'mc-mods' else 4471 if category == 'modpacks' else None
+        if not class_id:
+            return None
+        
+        api_url = f"https://api.curseforge.com/v1/mods/search?gameId=432&slug={project_slug}&classId={class_id}"
         
         headers = {
             'Accept': 'application/json',
@@ -67,7 +73,7 @@ def get_curseforge_description(url):
             return None
         
         data = response.json()
-        if data.get('data') and len(data['data']) > 0:
+        if data.get('data'):
             return data['data'][0].get('summary')
         
         return None

--- a/fetchers/icon.py
+++ b/fetchers/icon.py
@@ -75,8 +75,14 @@ def get_curseforge_icon(url):
         if len(path_parts) < 3:
             return None
         
+        category = path_parts[1]
         project_slug = path_parts[2]
-        api_url = f"https://api.curseforge.com/v1/mods/search?gameId=432&slug={project_slug}"
+        
+        class_id = 6 if category == 'mc-mods' else 4471 if category == 'modpacks' else None
+        if not class_id:
+            return None
+        
+        api_url = f"https://api.curseforge.com/v1/mods/search?gameId=432&slug={project_slug}&classId={class_id}"
         
         headers = {
             'Accept': 'application/json',
@@ -88,7 +94,7 @@ def get_curseforge_icon(url):
             return None
         
         data = response.json()
-        if data.get('data') and len(data['data']) > 0:
+        if data.get('data'):
             logo = data['data'][0].get('logo')
             if logo:
                 icon_url = logo.get('thumbnailUrl') or logo.get('url')

--- a/fetchers/titles.py
+++ b/fetchers/titles.py
@@ -54,8 +54,14 @@ def get_curseforge_title(url):
         if len(path_parts) < 3:
             return None
         
+        category = path_parts[1]
         project_slug = path_parts[2]
-        api_url = f"https://api.curseforge.com/v1/mods/search?gameId=432&slug={project_slug}"
+        
+        class_id = 6 if category == 'mc-mods' else 4471 if category == 'modpacks' else None
+        if not class_id:
+            return None
+        
+        api_url = f"https://api.curseforge.com/v1/mods/search?gameId=432&slug={project_slug}&classId={class_id}"
         
         headers = {
             'Accept': 'application/json',
@@ -67,7 +73,7 @@ def get_curseforge_title(url):
             return None
         
         data = response.json()
-        if data.get('data') and len(data['data']) > 0:
+        if data.get('data'):
             return data['data'][0].get('name')
         
         return None

--- a/fetchers/versions.py
+++ b/fetchers/versions.py
@@ -43,18 +43,14 @@ def get_spigot_game_versions(url):
             return None
         
         resource_id = match.group(1)
-        api_url = f"https://api.spiget.org/v2/resources/{resource_id}/versions?size=100"
+        api_url = f"https://api.spiget.org/v2/resources/{resource_id}"
         
         response = requests.get(api_url)
         if response.status_code != 200:
             return None
         
         data = response.json()
-        versions = set()
-        for version in data:
-            game_version = version.get('name', '')
-            matches = re.findall(r'1\.\d+(?:\.\d+)?', game_version)
-            versions.update(matches)
+        versions = data.get('testedVersions', [])
         
         return sorted(versions) if versions else []
     except Exception:
@@ -102,8 +98,14 @@ def get_curseforge_game_versions(url):
         if len(path_parts) < 3:
             return []
         
+        category = path_parts[1]
         project_slug = path_parts[2]
-        api_url = f"https://api.curseforge.com/v1/mods/search?gameId=432&slug={project_slug}"
+        
+        class_id = 6 if category == 'mc-mods' else 4471 if category == 'modpacks' else None
+        if not class_id:
+            return []
+        
+        api_url = f"https://api.curseforge.com/v1/mods/search?gameId=432&slug={project_slug}&classId={class_id}"
         
         headers = {
             'Accept': 'application/json',


### PR DESCRIPTION
- Fix Spigot fetcher to use testedVersions field instead of parsing plugin version names
- Fix CurseForge fetcher to distinguish between mods and modpacks using URL path category
- Add classId parameter to CurseForge API requests (6 for mc-mods, 4471 for modpacks)
- Now correctly returns Minecraft game versions instead of plugin/mod versions